### PR TITLE
Implement state system in ReactorAPI

### DIFF
--- a/reactor/gui/ReactorAPI.lua
+++ b/reactor/gui/ReactorAPI.lua
@@ -58,6 +58,7 @@ local function monitorReactor()
         state = ReactorStatus.ACTIVE
     else
         state = ReactorStatus.INACTIVE
+    end
 end
 
 local function getReactorInfo()


### PR DESCRIPTION
For easily exposing the reactor state in the output, the reactor needs to have a state variable.