### PR TITLE
Add reactor forced state

### DIFF
--- a/reactor/gui/ReactorAPI.lua
+++ b/reactor/gui/ReactorAPI.lua
@@ -13,7 +13,9 @@ local hysteresis_min = 0.3
 local ReactorStatus = {
     NOT_CONNECTED = 0,
     INACTIVE = 1,
-    ACTIVE = 2
+    ACTIVE = 2,
+    FORCE_INACTIVE = 3,
+    FORCE_ACTIVE = 4
 }
 
 local state = ReactorStatus.NOT_CONNECTED
@@ -37,14 +39,19 @@ local function monitorReactor()
         return
     end
 
+    if state == ReactorStatus.FORCE_ACTIVE then
+        return
+    end
+
+    if state == ReactorStatus.FORCE_INACTIVE then
+        return
+    end
+
     if matrix.getEnergy() / matrix.getMaxEnergy() >= hysteresis_max then
         if reactor.getActive() then
             reactor.setActive(false)
             logger.log(logger.LogStatus.INFO, "Maximum hysterises value reached. Turning reactor off.")
         end
-
-        state = ReactorStatus.INACTIVE
-        return
     end
 
     if matrix.getEnergy() / matrix.getMaxEnergy() <= hysteresis_min then
@@ -74,6 +81,10 @@ local function getReactorInfo()
 
     if state == ReactorStatus.NOT_CONNECTED then
         reactorInfo.Status = ReactorStatus.NOT_CONNECTED
+    elseif state == ReactorStatus.FORCE_ACTIVE then
+        reactorInfo.Status = ReactorStatus.FORCE_ACTIVE
+    elseif state == ReactorStatus.FORCE_INACTIVE then
+        reactorInfo.Status = ReactorStatus.FORCE_INACTIVE
     elseif state == ReactorStatus.ACTIVE then
         reactorInfo.Status = ReactorStatus.ACTIVE
     else

--- a/reactor/gui/ReactorAPI.lua
+++ b/reactor/gui/ReactorAPI.lua
@@ -32,6 +32,27 @@ local function calculateEnergyPerSecond()
     return (matrix.getEnergy() - previousEnergy) / screenInfo.ScreenRefreshTime
 end
 
+local function forceActive()
+    state = ReactorStatus.FORCE_ACTIVE
+    reactor.setActive(true)
+    logger.log(logger.LogStatus.WARNING, "Reactor now in forced active mode. It won't turn off without manual assistance.")
+end
+
+local function forceInactive()
+    state = ReactorStatus.FORCE_INACTIVE
+    reactor.setActive(false)
+    logger.log(logger.LogStatus.WARNING, "Reactor now in forced inactive mode. It won't turn on without manual assistance.")
+end
+
+local function disableForce()
+    if state == ReactorStatus.FORCE_ACTIVE then
+        state = ReactorStatus.ACTIVE
+    elseif state == ReactorStatus.FORCE_INACTIVE
+        state = ReactorStatus.INACTIVE
+    end
+    logger.log(logger.LogStatus.WARNING, "Forced mode deactivated.")
+end
+
 local function monitorReactor()
     if not component.isAvailable("br_reactor") or not component.isAvailable("induction_matrix") then
         state = ReactorStatus.NOT_CONNECTED


### PR DESCRIPTION
With these two new states, the reactor will stay on or off forever without manual intervention. Exiting the program however will not save this mode and bring the reactor program back into the automatic mode (stay between the two hysterises values).