### PR TITLE
Add management for hysteresis values

### DIFF
--- a/reactor/gui/ReactorAPI.lua
+++ b/reactor/gui/ReactorAPI.lua
@@ -132,4 +132,5 @@ local function getReactorInfo()
 end
 
 return { init = init, setHysteresisMax = setHysteresisMax, setHysteresisMin = setHysteresisMin, getHysteresisMin = getHysteresisMin,
-    getHysteresisMax = getHysteresisMax, monitorReactor = monitorReactor, getReactorInfo = getReactorInfo, ReactorStatus = ReactorStatus }
+    forceActive = forceActive, forceInactive = forceInactive, disableForce = disableForce, getHysteresisMax = getHysteresisMax,
+    monitorReactor = monitorReactor, getReactorInfo = getReactorInfo, ReactorStatus = ReactorStatus }

--- a/reactor/gui/ReactorAPI.lua
+++ b/reactor/gui/ReactorAPI.lua
@@ -84,11 +84,7 @@ local function monitorReactor()
         return
     end
 
-    if state == ReactorStatus.FORCE_ACTIVE then
-        return
-    end
-
-    if state == ReactorStatus.FORCE_INACTIVE then
+    if state == ReactorStatus.FORCE_ACTIVE or state == ReactorStatus.FORCE_INACTIVE then
         return
     end
 

--- a/reactor/gui/ReactorAPI.lua
+++ b/reactor/gui/ReactorAPI.lua
@@ -53,6 +53,22 @@ local function disableForce()
     logger.log(logger.LogStatus.WARNING, "Forced mode deactivated.")
 end
 
+local function setHysteresisMin(value)
+    hysteresis_min = value
+end
+
+local function setHysteresisMax(value)
+    hysteresis_max = value
+end
+
+local function getHysteresisMin()
+    return hysteresis_min
+end
+
+local function getHysteresisMax()
+    return hysteresis_max
+end
+
 local function monitorReactor()
     if not component.isAvailable("br_reactor") or not component.isAvailable("induction_matrix") then
         state = ReactorStatus.NOT_CONNECTED
@@ -115,4 +131,5 @@ local function getReactorInfo()
     return reactorInfo
 end
 
-return { init = init, monitorReactor = monitorReactor, getReactorInfo = getReactorInfo, ReactorStatus = ReactorStatus }
+return { init = init, setHysteresisMax = setHysteresisMax, setHysteresisMin = setHysteresisMin, getHysteresisMin = getHysteresisMin,
+    getHysteresisMax = getHysteresisMax, monitorReactor = monitorReactor, getReactorInfo = getReactorInfo, ReactorStatus = ReactorStatus }

--- a/reactor/gui/ReactorAPI.lua
+++ b/reactor/gui/ReactorAPI.lua
@@ -54,10 +54,18 @@ local function disableForce()
 end
 
 local function setHysteresisMin(value)
+    if value > 1 or value <= 0 or value >= hysteresis_max then
+        return
+    end
+
     hysteresis_min = value
 end
 
 local function setHysteresisMax(value)
+    if value > 1 or value <= 0 or value <= hysteresis_min then
+        return
+    end
+
     hysteresis_max = value
 end
 


### PR DESCRIPTION
The hysteresis values need to be exposed via an interface, so that they can be changed later via an UI. They are accessible via the getter and setters.